### PR TITLE
SUPESC-413: Added a product sku compliance check when finding prices by filter.

### DIFF
--- a/src/Spryker/Service/PriceProduct/Model/PriceProductMatcher.php
+++ b/src/Spryker/Service/PriceProduct/Model/PriceProductMatcher.php
@@ -207,6 +207,10 @@ class PriceProductMatcher implements PriceProductMatcherInterface
      */
     protected function checkPriceProductOnFilter(PriceProductTransfer $priceProductTransfer, PriceProductFilterTransfer $priceProductFilterTransfer): bool
     {
+        if ($priceProductTransfer->getSkuProduct() !== $priceProductFilterTransfer->getSku()) {
+            return false;
+        }
+
         if ($priceProductFilterTransfer->getPriceDimension() !== null) {
             $priceProductTransfer->requirePriceDimension();
 


### PR DESCRIPTION
Branch: backport/supesc-413/price-product-2.15.1
Ticket: https://spryker.atlassian.net/browse/SUPESC-413
Target Version: 2.15.1

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   PriceProduct           | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module PriceProduct

##### Change log

Fixes

- Adjusted `PriceProductService::resolveProductPriceByPriceProductFilter()` so now it returns the price for the product specified in the filter instead of returns the price specified in the last product.
- Adjusted `PriceProductService::resolveProductPricesByPriceProductFilter()` so now it returns the prices for the product specified in the filter instead of returns the price specified in the last product.
